### PR TITLE
Update limitations section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,9 +1149,6 @@ The hart registers are exposed as class attributes and implement step/run functi
 
 # Limitations
 
-It is not possible to change XLEN at run time by writing to the MISA
-register.
-
 The "round to nearest break tie to max magnitude" rounding mode is not
 implemented unless you compile with the softfloat library:
 ```


### PR DESCRIPTION
Removed information about changing XLEN at runtime.

This is part of the priv spec and therefore not a limitation:

```
The following changes have been made since version 1.12 of the Machine and Supervisor ISAs, which, while
not strictly backwards compatible, are not anticipated to cause software portability problems in practice:
* Redefined misa.MXL to be read-only, making MXLEN a constant.
```